### PR TITLE
Fixed Product Taxes

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
@@ -58,10 +58,12 @@ class Taxjar_SalesTax_Model_Sales_Total_Quote_Tax extends Mage_Tax_Model_Sales_T
             $address->setBaseShippingTaxAmount($shippingTaxAmount);
 
             if (count($items) > 0) {
+                $fptEnabled = $this->_getTaxConfig('weee/enable', $store->getId());
+
                 foreach ($items as $item) {
                     $itemTax = $smartCalcs->getResponseLineItem($item->getId());
 
-                    if ($this->_getTaxConfig('weee/enable', $store->getId())) {
+                    if ($fptEnabled) {
                         $fptAmount = $item->getWeeeTaxAppliedAmount() * $item->getQty();
                         $this->_addAmount($store->convertPrice($fptAmount));
                         $this->_addBaseAmount($fptAmount);

--- a/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
@@ -61,6 +61,12 @@ class Taxjar_SalesTax_Model_Sales_Total_Quote_Tax extends Mage_Tax_Model_Sales_T
                 foreach ($items as $item) {
                     $itemTax = $smartCalcs->getResponseLineItem($item->getId());
 
+                    if ($this->_getTaxConfig('weee/enable', $store->getId())) {
+                        $fptAmount = $item->getWeeeTaxAppliedAmount() * $item->getQty();
+                        $this->_addAmount($store->convertPrice($fptAmount));
+                        $this->_addBaseAmount($fptAmount);
+                    }
+
                     if (isset($itemTax)) {
                         $this->_addAmount($store->convertPrice($itemTax['tax_collectable']));
                         $this->_addBaseAmount($itemTax['tax_collectable']);
@@ -89,5 +95,17 @@ class Taxjar_SalesTax_Model_Sales_Total_Quote_Tax extends Mage_Tax_Model_Sales_T
             'taxjar/smartcalcs',
             array('address' => $address)
         );
+    }
+
+    /**
+     * Get Magento tax configuration field by store ID
+     *
+     * @param string $key
+     * @param integer $storeId
+     * @return string|bool
+     */
+    protected function _getTaxConfig($key, $storeId)
+    {
+        return Mage::getStoreConfig('tax/' . $key, $storeId);
     }
 }


### PR DESCRIPTION
This PR adds support for Magento's native fixed product tax feature. If FPT is enabled, we'll apply the FPT amount by line item after tax is calculated.

For example, if a merchant has to collect an eWaste Fee of $5 in CA and SmartCalcs returns $65 to collect, the total amount of tax would be $70.