### PR TITLE
Fixed Price Bundle Product Calculations

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -221,7 +221,10 @@ class Taxjar_SalesTax_Model_Smartcalcs
 
                 if ($item->getProductType() == Mage_Catalog_Model_Product_Type::TYPE_BUNDLE) {
                     $parentQuantities[$id] = $quantity;
-                    continue;
+
+                    if ($item->getProduct()->getPriceType() == Mage_Bundle_Model_Product_Price::PRICE_TYPE_DYNAMIC) {
+                        continue;
+                    }
                 }
 
                 if (isset($parentQuantities[$parentId])) {


### PR DESCRIPTION
This PR fixes calculations for bundle products with fixed pricing.

**Dynamic pricing** includes the unit price for both the bundle product and its associated simple products, which would add the amount multiple times if we didn't skip the base product.

**Fixed pricing** includes the unit price for just the bundle product, so we need to make sure it's included when building out the line items. The associated products have a $0 unit price so they're not included.