### PR TITLE
Added missing template modman mapping

### DIFF
--- a/modman
+++ b/modman
@@ -1,3 +1,4 @@
 app/etc/modules/*                                       app/etc/modules/
 app/code/community/Taxjar/SalesTax                      app/code/community/Taxjar/SalesTax
 var/connect/*                                           var/connect/
+app/design/adminhtml/default/default/template/*         app/design/adminhtml/default/default/template/


### PR DESCRIPTION
 Modman mapping has a missing directory, so when doing composer installs/updates not everything is mapped. 

This PR fixes the problem.