### PR TITLE
Fixed PHP7 type error when import rates is called from cron

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
@@ -26,7 +26,7 @@ class Taxjar_SalesTax_Model_Observer_ImportRates
     protected $_newRates = array();
     protected $_newShippingRates = array();
 
-    public function execute(Varien_Event_Observer $observer)
+    public function execute($ignoredObserverOrCronParameter = null)
     {
         $isEnabled = Mage::getStoreConfig('tax/taxjar/backup');
         $this->_apiKey = trim(Mage::getStoreConfig('tax/taxjar/apikey'));


### PR DESCRIPTION
This fixes a PHP7 error when the TaxJar Magento cronjob is calling `Taxjar_SalesTax_Model_Observer_ImportRates->execute()`.

```
PHP Fatal error: Uncaught TypeError: Argument 1 passed to Taxjar_SalesTax_Model_Observer_ImportRates::execute() must be an instance of Varien_Event_Observer, instance of Mage_Cron_Model_Schedule given, called in /var/www/html/app/code/core/Mage/Cron/Model/Observer.php on line 326 and defined in /var/www/html/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php:29
```