### PR TITLE
Fixed zip validation regex

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
@@ -79,7 +79,7 @@ class Taxjar_SalesTax_Model_Observer_ImportRates
             Mage::throwException('Please select at least one product tax class and one customer tax class to import backup rates from TaxJar.');
         }
 
-        if ($this->_storeZip && preg_match("/(\d{5}-\d{4})|(\d{5})/", $this->_storeZip)) {
+        if ($this->_storeZip && preg_match('/^(\d{5}-\d{4})|\d{5})$/', $this->_storeZip)) {
             $ratesJson = $this->_getRatesJson();
         } else {
             $this->_unsetBackupRates();


### PR DESCRIPTION
The ZIP code validation regex was not anchored, so it would match any string which contains 5 digits, eg `foo12345bar`.
Fixed it by adding start (`^`) and "end" (`$`) of string anchors.