### PR TITLE
Fixed syntax error in zip validation regex

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
@@ -79,7 +79,7 @@ class Taxjar_SalesTax_Model_Observer_ImportRates
             Mage::throwException('Please select at least one product tax class and one customer tax class to import backup rates from TaxJar.');
         }
 
-        if ($this->_storeZip && preg_match('/^(\d{5}-\d{4})|\d{5})$/', $this->_storeZip)) {
+        if ($this->_storeZip && preg_match('/^(\d{5}-\d{4}|\d{5})$/', $this->_storeZip)) {
             $ratesJson = $this->_getRatesJson();
         } else {
             $this->_unsetBackupRates();


### PR DESCRIPTION
There was a syntax error in PR #16 regex. This fixes that.

Didn't properly copy the changes over from our working branch. Sorry about that.