### PR TITLE
Fix tax on newly added cart items

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
@@ -58,8 +58,8 @@ class Taxjar_SalesTax_Model_Sales_Total_Quote_Tax extends Mage_Tax_Model_Sales_T
             $address->setBaseShippingTaxAmount($shippingTaxAmount);
 
             if (count($items) > 0) {
-                foreach ($items as $item) {
-                    $itemTax = $smartCalcs->getResponseLineItem($item->getId());
+                foreach ($items as $itemIndex => $item) {
+                    $itemTax = $smartCalcs->getResponseLineItem($itemIndex);
 
                     if (isset($itemTax)) {
                         $this->_addAmount($store->convertPrice($itemTax['tax_collectable']));

--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -210,8 +210,8 @@ class Taxjar_SalesTax_Model_Smartcalcs
         if (count($items) > 0) {
             $parentQuantities = array();
 
-            foreach ($items as $item) {
-                $id = $item->getId();
+            foreach ($items as $itemIndex => $item) {
+                $id = $itemIndex;
                 $parentId = $item->getParentItemId();
                 $quantity = $item->getQty();
                 $unitPrice = (float) $item->getPrice();


### PR DESCRIPTION
This PR resolves #13 by using the item index rather than its ID, which may not be set when:

- Customer is logged in or they have a zip code in their checkout session
- **Configuration > Sales > Checkout > After Adding a Product Redirect to Shopping Cart** is turned off for the Magento store
- Item is then added to the cart

#14 introduced the original fix, but we have some special logic in place to handle Magento bundle products via `getAllItems` and I wanted to simplify.