### PR TITLE
Jmt moving admin notifications event to admin only

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Logger.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Logger.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+/**
+ * TaxJar Logger
+ * Log transactions to a local file
+ */
+class Taxjar_SalesTax_Model_Logger
+{
+    protected $playback = array();
+    protected $isRecording;
+
+    /**
+     * Get the temp log filename
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return Mage::getBaseDir('log') . DS . 'taxjar.log';
+    }
+
+    /**
+     * Save a message to taxjar.log
+     *
+     * @param string $message
+     * @param string $label
+     * @throws LocalizedException
+     * @return void
+     */
+    public function log($message, $label = '') {
+        if(Mage::getIsDeveloperMode())
+        {
+            try {
+                if (!empty($label)) {
+                    $label = '[' . strtoupper($label) . '] ';
+                }
+
+                $timestamp = date('d M Y H:i:s', time());
+                $message = sprintf('%s%s - %s%s', PHP_EOL, $timestamp, $label, $message);
+                file_put_contents($this->getPath(), $message, FILE_APPEND);
+
+                if ($this->isRecording) {
+                    $this->playback[] = $message;
+                }
+            } catch (Exception $e) {
+                Mage::getSingleton('core/session')->addError(Mage::helper('taxjar')->__('Could not write to your Magento log directory under /var/log. Please make sure the directory is created and check permissions for %1.', Mage::getBaseDir('log')));
+            }
+        }
+    }
+
+    /**
+     * Enable log recording
+     *
+     * @return void
+     */
+    public function record()
+    {
+        $this->isRecording = true;
+    }
+
+    /**
+     * Return log recording
+     *
+     * @return array
+     */
+    public function playback()
+    {
+        return $this->playback;
+    }
+}

--- a/app/code/community/Taxjar/SalesTax/Model/Logger.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Logger.php
@@ -23,6 +23,14 @@ class Taxjar_SalesTax_Model_Logger
 {
     protected $playback = array();
     protected $isRecording;
+    protected $filename = 'default.log';
+
+
+    public function setFilename($filename)
+    {
+        $this->filename = $filename;
+        return $this;
+    }
 
     /**
      * Get the temp log filename
@@ -31,7 +39,7 @@ class Taxjar_SalesTax_Model_Logger
      */
     public function getPath()
     {
-        return Mage::getBaseDir('log') . DS . 'taxjar.log';
+        return Mage::getBaseDir('log') . DS .'taxjar' . DS . $this->filename;
     }
 
     /**
@@ -43,8 +51,7 @@ class Taxjar_SalesTax_Model_Logger
      * @return void
      */
     public function log($message, $label = '') {
-        if(Mage::getIsDeveloperMode())
-        {
+        if (Mage::getStoreConfig('tax/taxjar/debug')) {
             try {
                 if (!empty($label)) {
                     $label = '[' . strtoupper($label) . '] ';
@@ -52,6 +59,12 @@ class Taxjar_SalesTax_Model_Logger
 
                 $timestamp = date('d M Y H:i:s', time());
                 $message = sprintf('%s%s - %s%s', PHP_EOL, $timestamp, $label, $message);
+
+                if (!is_dir(dirname($this->getPath()))) {
+                    // dir doesn't exist, make it
+                    mkdir(dirname($this->getPath()));
+                }
+
                 file_put_contents($this->getPath(), $message, FILE_APPEND);
 
                 if ($this->isRecording) {

--- a/app/code/community/Taxjar/SalesTax/Model/Logger.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Logger.php
@@ -25,7 +25,11 @@ class Taxjar_SalesTax_Model_Logger
     protected $isRecording;
     protected $filename = 'default.log';
 
-
+    /**
+     * Sets the filename used for the logger
+     *
+     * @return Taxjar_SalesTax_Model_Logger
+     */
     public function setFilename($filename)
     {
         $this->filename = $filename;

--- a/app/code/community/Taxjar/SalesTax/Model/Logger.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Logger.php
@@ -28,6 +28,7 @@ class Taxjar_SalesTax_Model_Logger
     /**
      * Sets the filename used for the logger
      *
+     * @param string $filename
      * @return Taxjar_SalesTax_Model_Logger
      */
     public function setFilename($filename)

--- a/app/code/community/Taxjar/SalesTax/Model/Logger.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Logger.php
@@ -39,7 +39,7 @@ class Taxjar_SalesTax_Model_Logger
      */
     public function getPath()
     {
-        return Mage::getBaseDir('log') . DS .'taxjar' . DS . $this->filename;
+        return Mage::getBaseDir('log') . DS . 'taxjar' . DS . $this->filename;
     }
 
     /**

--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -26,7 +26,7 @@ class Taxjar_SalesTax_Model_Smartcalcs
 
     public function __construct($params = array())
     {
-        $this->_logger = Mage::getModel('taxjar/logger');
+        $this->_logger = Mage::getModel('taxjar/logger')->setFilename("calculations.log");
         $this->initTaxForOrder($params['address']);
     }
 
@@ -99,12 +99,9 @@ class Taxjar_SalesTax_Model_Smartcalcs
                 $response = $client->request('POST');
                 $this->_response = $response;
                 $this->_setSessionData('response', $response);
-                if ($response->getStatus() ==200 ) // Success
-                {
+                if ($response->getStatus() ==200 ) {
                     $this->_logger->log('Successful API response: ' . $response->getBody(), 'success');
-                }
-                else
-                {
+                } else {
                     $errorResponse = json_decode($response->getBody());
                     $this->_logger->log($errorResponse->status . ' ' . $errorResponse->error . ' - ' . $errorResponse->detail, 'error');
 

--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -26,7 +26,7 @@ class Taxjar_SalesTax_Model_Smartcalcs
 
     public function __construct($params = array())
     {
-        $this->_logger = Mage::getModel('taxjar/logger')->setFilename("calculations.log");
+        $this->_logger = Mage::getModel('taxjar/logger')->setFilename('calculations.log');
         $this->initTaxForOrder($params['address']);
     }
 
@@ -99,17 +99,17 @@ class Taxjar_SalesTax_Model_Smartcalcs
                 $response = $client->request('POST');
                 $this->_response = $response;
                 $this->_setSessionData('response', $response);
+
                 if (200 == $response->getStatus()) {
                     $this->_logger->log('Successful API response: ' . $response->getBody(), 'success');
                 } else {
                     $errorResponse = json_decode($response->getBody());
                     $this->_logger->log($errorResponse->status . ' ' . $errorResponse->error . ' - ' . $errorResponse->detail, 'error');
-
                 }
 
             } catch (Zend_Http_Client_Exception $e) {
                 // Catch API timeouts and network issues
-                $this->_logger->log('There has been an api timeout or a network issue between you and taxjar, please try again later.', 'error');
+                $this->_logger->log('API timeout or network issue between your store and TaxJar, please try again later.', 'error');
                 $this->_response = null;
                 $this->_unsetSessionData('response');
             }

--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -99,7 +99,7 @@ class Taxjar_SalesTax_Model_Smartcalcs
                 $response = $client->request('POST');
                 $this->_response = $response;
                 $this->_setSessionData('response', $response);
-                if ($response->getStatus() ==200 ) {
+                if (200 == $response->getStatus()) {
                     $this->_logger->log('Successful API response: ' . $response->getBody(), 'success');
                 } else {
                     $errorResponse = json_decode($response->getBody());

--- a/app/code/community/Taxjar/SalesTax/etc/config.xml
+++ b/app/code/community/Taxjar/SalesTax/etc/config.xml
@@ -71,24 +71,6 @@
             </salestax_setup>
         </resources>
         <events>
-            <admin_system_config_changed_section_tax>
-                <observers>
-                    <taxjar>
-                        <type>singleton</type>
-                        <class>taxjar/observer_configChanged</class>
-                        <method>execute</method>
-                    </taxjar>
-                </observers>
-            </admin_system_config_changed_section_tax>
-            <controller_action_predispatch_adminhtml_system_config_edit>
-                <observers>
-                    <taxjar>
-                        <type>singleton</type>
-                        <class>taxjar/observer_configReview</class>
-                        <method>execute</method>
-                    </taxjar>
-                </observers>
-            </controller_action_predispatch_adminhtml_system_config_edit>
             <taxjar_salestax_import_categories>
                 <observers>
                     <taxjar>
@@ -125,6 +107,10 @@
                     </taxjar>
                 </observers>
             </sales_quote_collect_totals_before>
+        </events>
+    </global>
+    <adminhtml>
+        <events>
             <controller_action_predispatch>
                 <observers>
                     <taxjar>
@@ -143,8 +129,26 @@
                     </taxjar>
                 </observers>
             </controller_action_layout_render_before>
+            <controller_action_predispatch_adminhtml_system_config_edit>
+                <observers>
+                    <taxjar>
+                        <type>singleton</type>
+                        <class>taxjar/observer_configReview</class>
+                        <method>execute</method>
+                    </taxjar>
+                </observers>
+            </controller_action_predispatch_adminhtml_system_config_edit>
+            <admin_system_config_changed_section_tax>
+                <observers>
+                    <taxjar>
+                        <type>singleton</type>
+                        <class>taxjar/observer_configChanged</class>
+                        <method>execute</method>
+                    </taxjar>
+                </observers>
+            </admin_system_config_changed_section_tax>
         </events>
-    </global>
+    </adminhtml>
     <admin>
         <routers>
             <adminhtml>


### PR DESCRIPTION
I found four events that I think should be moved to the admin only observer scope. Is there any reason that any of these should have global scope? 

- controller_action_predispatch
- controller_action_layout_render_before
- controller_action_predispatch_adminhtml_system_config_edit
- admin_system_config_changed_section_tax