### PR TITLE
Fixed bug in Smartcalcs, _getLineItems now properly multiplies out qu…

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
@@ -59,8 +59,8 @@ class Taxjar_SalesTax_Model_Sales_Total_Quote_Tax extends Mage_Tax_Model_Sales_T
 
             if (count($items) > 0) {
                 foreach ($items as $itemIndex => $item) {
-                    $itemTax = $smartCalcs->getResponseLineItem($itemIndex);
-
+                    $itemId = $item->getId() ? $item->getId() : $itemIndex;
+                    $itemTax = $smartCalcs->getResponseLineItem($itemId);
                     if (isset($itemTax)) {
                         $this->_addAmount($store->convertPrice($itemTax['tax_collectable']));
                         $this->_addBaseAmount($itemTax['tax_collectable']);

--- a/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Sales/Total/Quote/Tax.php
@@ -61,6 +61,7 @@ class Taxjar_SalesTax_Model_Sales_Total_Quote_Tax extends Mage_Tax_Model_Sales_T
                 foreach ($items as $itemIndex => $item) {
                     $itemId = $item->getId() ? $item->getId() : $itemIndex;
                     $itemTax = $smartCalcs->getResponseLineItem($itemId);
+                    
                     if (isset($itemTax)) {
                         $this->_addAmount($store->convertPrice($itemTax['tax_collectable']));
                         $this->_addBaseAmount($itemTax['tax_collectable']);

--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -227,7 +227,7 @@ class Taxjar_SalesTax_Model_Smartcalcs
             $parentQuantities = array();
 
             foreach ($items as $itemIndex => $item) {
-                $id = $item->getId();
+                $id = $item->getId() ? $item->getId() : $itemIndex;
                 $parentId = $item->getParentItemId();
                 $quantity = $item->getQty();
                 $unitPrice = (float) $item->getPrice();

--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -227,7 +227,7 @@ class Taxjar_SalesTax_Model_Smartcalcs
             $parentQuantities = array();
 
             foreach ($items as $itemIndex => $item) {
-                $id = $itemIndex;
+                $id = $item->getId();
                 $parentId = $item->getParentItemId();
                 $quantity = $item->getQty();
                 $unitPrice = (float) $item->getPrice();


### PR DESCRIPTION
…antities. Was not working because we were using two different points of reference for the item id. Now we use the sam reference. 