### PR TITLE
SmartCalcs Connect Reporting Access Fix

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Comment.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Comment.php
@@ -125,7 +125,7 @@ EOT;
                     var data = JSON.parse(e.data);
                     if (data.api_token && data.email) {
                         window.connectPopup.postMessage('Data received', '{$authUrl}');
-                        window.location = encodeURI('{$connectUrl}api_key=' + data.api_token + '&api_email=' + data.email);
+                        window.location = encodeURI('{$connectUrl}api_key=' + data.api_token + '&api_email=' + data.email + '&reporting_access=' + data.reporting_access);
                     } else {
                         throw 'Invalid data';
                     }


### PR DESCRIPTION
This PR ensures the `reporting_access` param is passed to our extension for determining whether transaction sync can be enabled. Once fixed, merchants already on a paid subscription or trial won't have to re-authenticate to unlock transaction sync.