### PR TITLE
Don't save tax calculations twice, delete tax calculations in bulk ba…

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Import/Rule.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Import/Rule.php
@@ -24,26 +24,27 @@ class Taxjar_SalesTax_Model_Import_Rule
     /**
      * Create new tax rule based on code
      *
-     * @param string $code
-     * @param integer $customerClass
-     * @param integer $productClass
+     * @param string  $code
+     * @param array   $customerClasses
+     * @param array   $productClasses
      * @param integer $position
-     * @param array $rates
+     * @param array   $rates
+     *
      * @return void
      */
     public function create($code, $customerClasses, $productClasses, $position, $rates)
     {
         $rule = Mage::getModel('tax/calculation_rule')->load($code, 'code');
 
-        $attributes = array(
+        $attributes = [
             'code' => $code,
             'tax_customer_class' => $customerClasses,
             'tax_product_class' => $productClasses,
             'position' => $position,
             'priority' => 1
-        );
+        ];
 
-        if (isset($rule)) {
+        if ($rule && $rule->getId()) {
             $attributes['tax_rate'] = array_merge($rule->getRates(), $rates);
             $rule->delete();
         } else {
@@ -54,6 +55,5 @@ class Taxjar_SalesTax_Model_Import_Rule
         $ruleModel->setData($attributes);
         $ruleModel->setCalculateSubtotal(0);
         $ruleModel->save();
-        $ruleModel->saveCalculationData();
     }
 }


### PR DESCRIPTION
…sed on tax calculation rate id

In case of a large number of product and customer tax classes used for backup tax rates - current implementation may lead to an ineffective database usage, issuing hundreds of thousands separate database queries.

Two most important points in this update:

1. We don't call `$ruleModel->saveCalculationData();` explicitly, but rely on `_afterSave()` method in `Mage_Tax_Model_Calculation_Rule` class.
2. We don't use individual tax calculation models for deletion, but instead issue a delete statement based on multiple tax calculation ids.