### PR TITLE
Use website specific shipping origin for backup tax rates import

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Client.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Client.php
@@ -25,11 +25,55 @@ class Taxjar_SalesTax_Model_Client
     protected $_version = 'v2';
     protected $_storeZip;
     protected $_storeRegionCode;
+    protected $_storeRegionId;
 
+    /**
+     * Use website specific shipping origin address if possible,
+     * fallback to global value otherwise.
+     */
     public function __construct()
     {
-        $this->_storeZip = trim(Mage::getStoreConfig('shipping/origin/postcode'));
-        $this->_storeRegionCode = Mage::getModel('directory/region')->load(Mage::getStoreConfig('shipping/origin/region_id'))->getCode();
+        $websiteForShippingOrigin = Mage::getStoreConfig('tax/taxjar/shipping_origin_website');
+        if ($websiteForShippingOrigin) {
+            $this->_storeZip = trim(
+                Mage::app()
+                    ->getWebsite($websiteForShippingOrigin)
+                    ->getConfig('shipping/origin/postcode')
+            );
+            $this->_storeRegionId = Mage::app()
+                ->getWebsite($websiteForShippingOrigin)
+                ->getConfig('shipping/origin/region_id');
+
+        } else {
+            $this->_storeZip = trim(Mage::getStoreConfig('shipping/origin/postcode'));
+            $this->_storeRegionId = Mage::getStoreConfig('shipping/origin/region_id');
+        }
+
+        $this->_storeRegionCode = Mage::getModel('directory/region')->load($this->_storeRegionId)->getCode();
+    }
+
+    /**
+     * @return integer
+     */
+    public function getStoreRegionId()
+    {
+        return $this->_storeRegionId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStoreRegionCode()
+    {
+        return $this->_storeRegionCode;
+    }
+
+    /**
+     * @return integer
+     */
+    public function getStoreZip()
+    {
+        return $this->_storeZip;
     }
 
     /**

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportCategories.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportCategories.php
@@ -25,7 +25,7 @@ class Taxjar_SalesTax_Model_Observer_ImportCategories
         $this->_apiKey = trim(Mage::getStoreConfig('tax/taxjar/apikey'));
 
         if ($this->_apiKey) {
-            $this->_client = Mage::getModel('taxjar/client');
+            $this->_client = Mage::getSingleton('taxjar/client');
             $this->_importCategories();
         }
     }

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportData.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportData.php
@@ -23,13 +23,13 @@ class Taxjar_SalesTax_Model_Observer_ImportData
     public function execute(Varien_Event_Observer $observer)
     {
         $this->_apiKey = trim(Mage::getStoreConfig('tax/taxjar/apikey'));
-        $storeRegion = Mage::getModel('directory/region')->load(Mage::getStoreConfig('shipping/origin/region_id'));
-        $storeRegionCode = $storeRegion->getCode();
-
         if ($this->_apiKey) {
-            $this->_client = Mage::getModel('taxjar/client');
+            $this->_client = Mage::getSingleton('taxjar/client');
+            $storeRegion = Mage::getModel('directory/region')
+                ->load($this->_client->getStoreRegionId());
+            $storeRegionCode = $storeRegion->getCode();
 
-            if (isset($storeRegionCode) && $storeRegion->getCountryId() == 'US') {
+            if (isset($storeRegionCode) && $storeRegion->getCountryId() === 'US') {
                 $this->_setConfiguration();
             }
         }

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportRates.php
@@ -32,9 +32,11 @@ class Taxjar_SalesTax_Model_Observer_ImportRates
         $this->_apiKey = trim(Mage::getStoreConfig('tax/taxjar/apikey'));
 
         if ($isEnabled && $this->_apiKey) {
-            $this->_client = Mage::getModel('taxjar/client');
-            $this->_storeZip = trim(Mage::getStoreConfig('shipping/origin/postcode'));
-            $this->_storeRegion = Mage::getModel('directory/region')->load(Mage::getStoreConfig('shipping/origin/region_id'));
+            $this->_client = Mage::getSingleton('taxjar/client');
+            $this->_storeZip = $this->_client->getStoreZip();
+            $this->_storeRegion = Mage::getModel('directory/region')
+                ->load($this->_client->getStoreRegionId());
+
             $this->_customerTaxClasses = explode(',', Mage::getStoreConfig('tax/taxjar/customer_tax_classes'));
             $this->_productTaxClasses = explode(',', Mage::getStoreConfig('tax/taxjar/product_tax_classes'));
             $this->_importRates();

--- a/app/code/community/Taxjar/SalesTax/Model/Source/Website.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Source/Website.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2018 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+/**
+ * Source model for website based shipping origin
+ *
+ * @author Taxjar (support@taxjar.com)
+ */
+class Taxjar_SalesTax_Model_Source_Website
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $output = [];
+        $output[] = ['label' => '', 'value' => ''];
+
+        $websites = Mage::app()->getWebsites();
+
+        /** @var Mage_Core_Model_Website $website */
+        foreach($websites as $website) {
+            $output[] = ['value' => $website->getId(), 'label' => $website->getName()];
+        }
+
+        return $output;
+    }
+}

--- a/app/code/community/Taxjar/SalesTax/etc/system.xml
+++ b/app/code/community/Taxjar/SalesTax/etc/system.xml
@@ -79,6 +79,19 @@
                             <show_in_store>1</show_in_store>
                             <depends><connected>1</connected></depends>
                         </customer_tax_classes>
+                        <shipping_origin_website translate="label">
+                            <label>Shipping Origin Website</label>
+                            <comment>Use shipping origin specified for a chosen website.</comment>
+                            <source_model>taxjar/source_website</source_model>
+                            <frontend_type>select</frontend_type>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                            <depends>
+                                <connected>1</connected>
+                            </depends>
+                        </shipping_origin_website>
                         <debug translate="label">
                             <label>Debug Mode</label>
                             <comment>
@@ -86,7 +99,7 @@
                             </comment>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <frontend_type>select</frontend_type>
-                            <sort_order>10</sort_order>
+                            <sort_order>11</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -96,7 +109,7 @@
                             <label>API Token</label>
                             <comment>Your TaxJar API token for sales tax calculations and backup rates.</comment>
                             <frontend_type>text</frontend_type>
-                            <sort_order>11</sort_order>
+                            <sort_order>12</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>11</show_in_store>


### PR DESCRIPTION
Currently it's impossible to import backup tax rates if client's default shipping origin is set to non US based address. With this change we add an additional setting which allows the client to choose a relevant website with US based shipping origin. During the import process we check if this setting is used, otherwise fallback to global shipping origin, so it won't have an effect on existing merchants.