### PR TITLE
Rename Tax Category "None" to "Fully Taxable"

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Categories.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Categories.php
@@ -34,7 +34,7 @@ class Taxjar_SalesTax_Model_Categories
 
         $output = array(
             array(
-                'label' => 'None',
+                'label' => 'Fully Taxable',
                 'value' => ''
             )
         );


### PR DESCRIPTION
When choosing a TaxJar Category for Product Tax Classes, the "None"
category was confusing users who mistakenly assumed it meant no taxes
would be applied.  Renaming it to "Fully Taxable" should help clarify
the proper use case.