### PR TITLE
Change bundle products to report individual items

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Transaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction.php
@@ -105,8 +105,21 @@ class Taxjar_SalesTax_Model_Transaction
         $parentTaxes = $this->getParentAmounts('tax', $items, $type);
 
         foreach ($items as $item) {
-            if ($item->getProductType() == 'bundle' || ($item->getParentItemId() && $item->getParentItem()->getProductType() !== 'bundle')) {
-                continue;
+            $itemType = $item->getProductType();
+            $parentItem = $item->getParentItem();
+
+            if (($itemType == 'simple' || $itemType == 'virtual') && $item->getParentItemId()) {
+                if (!empty($parentItem) && $parentItem->getProductType() == 'bundle') {
+                    if ($parentItem->getProduct()->getPriceType() == 1) {
+                        continue;  // Skip children of fixed price bundles
+                    }
+                } else {
+                    continue;  // Skip children of configurable products
+                }
+            }
+
+            if ($itemType == 'bundle' && $item->getProduct()->getPriceType() != 1) {
+                continue;  // Skip dynamic bundle parent item
             }
 
             if (method_exists($item, 'getOrderItem') && $item->getOrderItem()->getParentItemId()) {

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction.php
@@ -105,7 +105,7 @@ class Taxjar_SalesTax_Model_Transaction
         $parentTaxes = $this->getParentAmounts('tax', $items, $type);
 
         foreach ($items as $item) {
-            if ($item->getParentItemId()) {
+            if ($item->getProductType() == 'bundle' || ($item->getParentItemId() && $item->getParentItem()->getProductType() !== 'bundle')) {
                 continue;
             }
 

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction.php
@@ -110,7 +110,7 @@ class Taxjar_SalesTax_Model_Transaction
 
             if (($itemType == 'simple' || $itemType == 'virtual') && $item->getParentItemId()) {
                 if (!empty($parentItem) && $parentItem->getProductType() == 'bundle') {
-                    if ($parentItem->getProduct()->getPriceType() == 1) {
+                    if ($parentItem->getProduct()->getPriceType() == Mage_Bundle_Model_Product_Price::PRICE_TYPE_FIXED) {
                         continue;  // Skip children of fixed price bundles
                     }
                 } else {
@@ -118,7 +118,7 @@ class Taxjar_SalesTax_Model_Transaction
                 }
             }
 
-            if ($itemType == 'bundle' && $item->getProduct()->getPriceType() != 1) {
+            if ($itemType == 'bundle' && $item->getProduct()->getPriceType() != Mage_Bundle_Model_Product_Price::PRICE_TYPE_FIXED) {
                 continue;  // Skip dynamic bundle parent item
             }
 


### PR DESCRIPTION
Because bundle products are a collection of simple products and don't
have their own tax class, they were incorrectly reported with 99999.
Tracking the individual items resolves this and increases transparency.