### PR TITLE
Ensure country/state is set when syncing TJ nexus

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Tax/Nexus.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Tax/Nexus.php
@@ -91,6 +91,14 @@ class Taxjar_SalesTax_Model_Tax_Nexus extends Mage_Core_Model_Abstract
             $addresses = $nexusJson['addresses'];
 
             foreach($addresses as $address) {
+                if (!isset($address['country']) || empty($address['country'])) {
+                    continue;
+                }
+
+                if (($address['country'] == 'US' || $address['country'] == 'CA') && (!isset($address['state']) || empty($address['state']))) {
+                    continue;
+                }
+
                 $addressRegion = Mage::getModel('directory/region')->loadByCode($address['state'], $address['country']);
                 $addressCountry = Mage::getModel('directory/country')->loadByCode($address['country']);
                 $addressCollection = Mage::getModel('taxjar/tax_nexus')->getCollection();
@@ -143,6 +151,11 @@ class Taxjar_SalesTax_Model_Tax_Nexus extends Mage_Core_Model_Abstract
 
         if (!Zend_Validate::is($this->getCountryId(), 'NotEmpty')) {
             $errors[] = Mage::helper('taxjar')->__('Country can\'t be empty');
+        }
+
+        if (($this->getCountryId() == 'US' || $this->getCountryId() == 'CA') &&
+            !Zend_Validate::is($this->getRegionId(), 'NotEmpty')) {
+            $errors[] = Mage::helper('taxjar')->__('State can\'t be empty if country is US/Canada');
         }
 
         if (!$this->getId()) {


### PR DESCRIPTION
When syncing nexus addresses from TaxJar, ensure the country is set
before saving the address.  If the country is US/Canada, ensure the
state is also set.