### PR TITLE
Pi 99 sync refund event

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Observer/BackfillTransactions.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/BackfillTransactions.php
@@ -84,7 +84,9 @@ class Taxjar_SalesTax_Model_Observer_BackfillTransactions
                 $orderTransaction->build($order);
                 $orderTransaction->push();
 
-                $creditMemos = $order->getCreditmemosCollection();
+                /** @var Mage_Sales_Model_Entity_Order_Creditmemo_Collection $creditMemos */
+                $creditMemos = Mage::getModel('sales/order_creditmemo')->getCollection();
+                $creditMemos->setOrderFilter($order);
 
                 foreach ($creditMemos as $creditMemo) {
                     $refundTransaction = Mage::getModel('taxjar/transaction_refund');

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/SyncRefund.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/SyncRefund.php
@@ -29,8 +29,8 @@ class Taxjar_SalesTax_Model_Observer_SyncRefund
             return $this;
         }
 
-        if (!Mage::registry('taxjar_sync')) {
-            Mage::register('taxjar_sync', true);
+        if (!Mage::registry('taxjar_sync_refund')) {
+            Mage::register('taxjar_sync_refund', true);
         } else {
             return $this;
 

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/SyncRefund.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/SyncRefund.php
@@ -35,12 +35,10 @@ class Taxjar_SalesTax_Model_Observer_SyncRefund
             return $this;
 
         }
+
         /** @var Mage_Sales_Model_Order_Creditmemo $creditmemo */
         $creditmemo = $observer->getCreditmemo();
         $order = $creditmemo->getOrder();
-
-        // Force the order to load the most recent data
-        $order->load($order->getId());
 
         $orderTransaction = Mage::getModel('taxjar/transaction_order');
 

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/SyncRefund.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/SyncRefund.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+class Taxjar_SalesTax_Model_Observer_SyncRefund
+{
+    /**
+     * @param Varien_Event_Observer $observer
+     * @return $this
+     */
+    public function execute(Varien_Event_Observer $observer)
+    {
+        $syncEnabled = Mage::getStoreConfig('tax/taxjar/transactions');
+
+        if (!$syncEnabled) {
+            return $this;
+        }
+
+        if (!Mage::registry('taxjar_sync')) {
+            Mage::register('taxjar_sync', true);
+        } else {
+            return $this;
+
+        }
+        /** @var Mage_Sales_Model_Order_Creditmemo $creditmemo */
+        $creditmemo = $observer->getCreditmemo();
+        $order = $creditmemo->getOrder();
+
+        // Force the order to load the most recent data
+        $order->load($order->getId());
+
+        $orderTransaction = Mage::getModel('taxjar/transaction_order');
+
+        if ($orderTransaction->isSyncable($order)) {
+            try {
+                $refundTransaction = Mage::getModel('taxjar/transaction_refund');
+                $refundTransaction->build($order, $creditmemo);
+                $refundTransaction->push();
+
+                if ($observer->getData('order_id')) {
+                    Mage::getSingleton('adminhtml/session')->addSuccess(Mage::helper('taxjar')->__('Credit memo successfully synced to TaxJar.'));
+                }
+            } catch (Exception $e) {
+                Mage::getSingleton('adminhtml/session')->addError($e->getMessage());
+            }
+        } else {
+            if ($observer->getData('order_id')) {  // update
+                Mage::getSingleton('adminhtml/session')->addError(Mage::helper('taxjar')->__('This credit memo was not synced to TaxJar.'));
+            }
+        }
+
+        return $this;
+    }
+}

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/SyncTransaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/SyncTransaction.php
@@ -47,7 +47,9 @@ class Taxjar_SalesTax_Model_Observer_SyncTransaction
                 $orderTransaction->build($order);
                 $orderTransaction->push();
 
-                $creditmemos = $order->getCreditmemosCollection();
+                /** @var Mage_Sales_Model_Entity_Order_Creditmemo_Collection $creditmemos */
+                $creditmemos = Mage::getModel('sales/order_creditmemo')->getCollection();
+                $creditmemos->setOrderFilter($order);
 
                 foreach ($creditmemos as $creditmemo) {
                     $refundTransaction = Mage::getModel('taxjar/transaction_refund');

--- a/app/code/community/Taxjar/SalesTax/etc/config.xml
+++ b/app/code/community/Taxjar/SalesTax/etc/config.xml
@@ -107,6 +107,15 @@
                     </taxjar>
                 </observers>
             </sales_order_save_after>
+            <sales_order_creditmemo_save_after>
+                <observers>
+                    <taxjar>
+                        <type>singleton</type>
+                        <class>taxjar/observer_syncRefund</class>
+                        <method>execute</method>
+                    </taxjar>
+                </observers>
+            </sales_order_creditmemo_save_after>
             <sales_quote_collect_totals_before>
                 <observers>
                     <taxjar>

--- a/app/code/community/Taxjar/SalesTax/etc/config.xml
+++ b/app/code/community/Taxjar/SalesTax/etc/config.xml
@@ -107,7 +107,7 @@
                     </taxjar>
                 </observers>
             </sales_order_save_after>
-            <sales_order_payment_refund>
+            <sales_order_creditmemo_save_after>
                 <observers>
                     <taxjar>
                         <type>singleton</type>
@@ -115,7 +115,7 @@
                         <method>execute</method>
                     </taxjar>
                 </observers>
-            </sales_order_payment_refund>
+            </sales_order_creditmemo_save_after>
             <sales_quote_collect_totals_before>
                 <observers>
                     <taxjar>

--- a/app/code/community/Taxjar/SalesTax/etc/config.xml
+++ b/app/code/community/Taxjar/SalesTax/etc/config.xml
@@ -107,7 +107,7 @@
                     </taxjar>
                 </observers>
             </sales_order_save_after>
-            <sales_order_creditmemo_save_after>
+            <sales_order_payment_refund>
                 <observers>
                     <taxjar>
                         <type>singleton</type>
@@ -115,7 +115,7 @@
                         <method>execute</method>
                     </taxjar>
                 </observers>
-            </sales_order_creditmemo_save_after>
+            </sales_order_payment_refund>
             <sales_quote_collect_totals_before>
                 <observers>
                     <taxjar>


### PR DESCRIPTION
This PR creates an observer on the sales_order_payment_refund to sync refunds to TaxJar when it is called.  

It also reworks loading credit memos (in SyncTransactions and BackfillTransactions) to circumvent a caching issue that prevent all credit memos from being loaded in the collection.  