### PR TITLE
Pi 176 bundle product credit memo 99999

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
@@ -49,11 +49,16 @@ class Taxjar_SalesTax_Model_Transaction_Refund extends Taxjar_SalesTax_Model_Tra
             'sales_tax' => $salesTax
         );
 
+        $items = array();
+        foreach ($creditmemo->getAllItems() as $item) {
+            $items[] = Mage::getModel('sales/order_item')->load($item->getOrderItemId());
+        }
+
         $this->request = array_merge(
             $refund,
             $this->buildFromAddress($order->getStoreId()),
             $this->buildToAddress($order),
-            $this->buildLineItems($order, $creditmemo->getAllItems(), 'refund')
+            $this->buildLineItems($order, $items, 'refund')
         );
 
         if (isset($this->request['line_items'])) {

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
@@ -35,6 +35,7 @@ class Taxjar_SalesTax_Model_Transaction_Refund extends Taxjar_SalesTax_Model_Tra
         $salesTax = (float) $creditmemo->getTaxAmount();
         $adjustment = (float) $creditmemo->getAdjustment();
         $itemDiscounts = 0;
+        $items = array();
 
         $this->originalOrder = $order;
         $this->originalRefund = $creditmemo;
@@ -49,7 +50,6 @@ class Taxjar_SalesTax_Model_Transaction_Refund extends Taxjar_SalesTax_Model_Tra
             'sales_tax' => $salesTax
         );
 
-        $items = array();
         foreach ($creditmemo->getAllItems() as $item) {
             $items[] = Mage::getModel('sales/order_item')->load($item->getOrderItemId());
         }


### PR DESCRIPTION
When issuing a refund, the items passed to _buildLineItems() where
Order_Creditmemo_Item instead of the expected Order_Item.  This caused
$itemType in Model/Transaction.php to be null and 99999 reported as
the tax class.  Looking up the Order_Items resolves this.