### PR TITLE
Remove 99999s when product tax class is "none"

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -249,8 +249,6 @@ class Taxjar_SalesTax_Model_Smartcalcs
                 if ($item->getProduct()->getTaxClassId()) {
                     $taxClass = Mage::getModel('tax/class')->load($item->getProduct()->getTaxClassId());
                     $taxCode = $taxClass->getTjSalestaxCode();
-                } else {
-                    $taxCode = '99999';
                 }
 
                 if (Mage::getEdition() == 'Enterprise') {

--- a/app/code/community/Taxjar/SalesTax/etc/config.xml
+++ b/app/code/community/Taxjar/SalesTax/etc/config.xml
@@ -19,7 +19,7 @@
 <config>
     <modules>
         <Taxjar_SalesTax>
-            <version>2.4.1</version>
+            <version>2.4.2</version>
         </Taxjar_SalesTax>
     </modules>
     <global>

--- a/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-2.4.1-2.4.2.php
+++ b/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-2.4.1-2.4.2.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2017 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Eav_Model_Entity_Setup $installer */
+//$installer = $this;
+//$installer->startSetup();
+
+/** @var Mage_Eav_Model_Entity_Setup $installer */
+$installer = new Mage_Eav_Model_Entity_Setup('core_setup');
+$installer->startSetup();
+
+try {
+    $url = 'https://www.taxjar.com/guides/integrations/magento/#product-sales-tax-exemptions';
+    $note = 'TaxJar requires a product tax class assigned to a TaxJar category in order to exempt products from sales 
+    tax. <a href="' . $url . '" target="_blank">Click here</a> to learn more.';
+
+    $installer->updateAttribute(Mage_Catalog_Model_Product::ENTITY, 'tax_class_id', 'note', $note);
+} catch (Exception $e) {
+    Mage::logException($e);
+}
+
+$installer->endSetup();

--- a/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-2.4.1-2.4.2.php
+++ b/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-2.4.1-2.4.2.php
@@ -16,10 +16,6 @@
  */
 
 /** @var Mage_Eav_Model_Entity_Setup $installer */
-//$installer = $this;
-//$installer->startSetup();
-
-/** @var Mage_Eav_Model_Entity_Setup $installer */
 $installer = new Mage_Eav_Model_Entity_Setup('core_setup');
 $installer->startSetup();
 


### PR DESCRIPTION
Previously products with a tax class of "none" were assigned 99999 to
mark them as tax exempt. This change removes that functionality and
requires users to pick a valid tax class to mark the product as exempt.
The "none" tax class now defaults to fully taxable.