### PR TITLE
Fix broken call to categories endpoint

### DIFF
--- a/app/code/community/Taxjar/SalesTax/data/salestax_setup/data-upgrade-2.4.2-2.4.3.php
+++ b/app/code/community/Taxjar/SalesTax/data/salestax_setup/data-upgrade-2.4.2-2.4.3.php
@@ -25,7 +25,7 @@ if ($apiKey) {
     $client = Mage::getModel('taxjar/client');
 
     try {
-        $configJson = $client->getResource($apiKey, 'config');
+        $configJson = $client->getResource('config');
 
         if (is_array($configJson) && isset($configJson['configuration']) && isset($configJson['configuration']['states'])) {
             $states = explode(',', $configJson['configuration']['states']);


### PR DESCRIPTION
Data upgrade 2.4.2-2.4.3 makes a call to the categories endpoint but was
returning a 404 due to an error.