### PR TITLE
Rework product tax category storage

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Block/Adminhtml/Tax/Class/Edit/Form.php
+++ b/app/code/community/Taxjar/SalesTax/Block/Adminhtml/Tax/Class/Edit/Form.php
@@ -31,7 +31,7 @@ class Taxjar_SalesTax_Block_Adminhtml_Tax_Class_Edit_Form extends Mage_Adminhtml
                     'name'  => 'tj_salestax_code',
                     'label' => Mage::helper('taxjar')->__('TaxJar Category'),
                     'value' => $currentClass->getTjSalestaxCode(),
-                    'values' => Mage::getModel('taxjar/categories')->toOptionArray()
+                    'values' => Mage::getModel('taxjar/tax_category')->getCollection()->toOptionArray()
                 )
             );
         }

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportCategories.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportCategories.php
@@ -34,7 +34,7 @@ class Taxjar_SalesTax_Model_Observer_ImportCategories
      * Get TaxJar product categories
      *
      * @param void
-     * @return string
+     * @return array
      */
     private function _getCategoryJson()
     {
@@ -51,7 +51,18 @@ class Taxjar_SalesTax_Model_Observer_ImportCategories
     private function _importCategories()
     {
         $categoryJson = $this->_getCategoryJson();
-        Mage::getConfig()->saveConfig('tax/taxjar/categories', json_encode($categoryJson));
-        Mage::getConfig()->reinit();
+
+        foreach ($categoryJson as $json) {
+            $category = Mage::getModel('taxjar/tax_category')->load(trim($json['product_tax_code']),
+                'product_tax_code');
+            $plusOnly = (strpos(trim($json['description']), '*(PLUS ONLY)*') !== false) ? true : false;
+
+            $category->setProductTaxCode(trim($json['product_tax_code']));
+            $category->setName(trim($json['name']));
+            $category->setDescription(trim($json['description']));
+            $category->setPlusOnly($plusOnly);
+
+            $category->save();
+        }
     }
 }

--- a/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+class Taxjar_SalesTax_Model_Resource_Tax_Category extends Mage_Core_Model_Resource_Db_Abstract
+{
+    /**
+     * Resource initialization
+     */
+    public function _construct()
+    {
+        $this->_init('taxjar/tax_category', 'id');
+    }
+}

--- a/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category/Collection.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category/Collection.php
@@ -15,37 +15,38 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
-/**
- * TaxJar Categories Model
- * Populates tax category dropdown under
-*/
-class Taxjar_SalesTax_Model_Categories
+class Taxjar_SalesTax_Model_Resource_Tax_Category_Collection extends Mage_Core_Model_Resource_Db_Collection_Abstract
 {
     /**
-     * Populate dropdown options
+     * Resource initialization
+     */
+    public function _construct()
+    {
+        $this->_init('taxjar/tax_category');
+    }
+
+    /**
+     * Retrieve option array
      *
-     * @param void
      * @return array
      */
     public function toOptionArray()
     {
-        $categories = json_decode(Mage::getStoreConfig('tax/taxjar/categories'), true);
-        $categories = Mage::helper('taxjar')->array_sort($categories, 'product_tax_code', SORT_ASC);
-
-        $output = array(
+        $options = array(
             array(
                 'label' => 'Fully Taxable',
                 'value' => ''
             )
         );
 
-        foreach($categories as $category) {
-            $output[] = array(
-                'label' => $category['name'] . ' (' . $category['product_tax_code'] . ')',
-                'value' => $category['product_tax_code']
+        foreach ($this as $category) {
+            $options[] = array(
+                'label' => $category->getName() . ' (' . $category->getProductTaxCode() . ')' .
+                    ($category->getPlusOnly() ? ' *(PLUS ONLY)*' : ''),
+                'value' => $category->getProductTaxCode()
             );
         }
 
-        return $output;
+        return $options;
     }
 }

--- a/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category/Collection.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category/Collection.php
@@ -32,6 +32,7 @@ class Taxjar_SalesTax_Model_Resource_Tax_Category_Collection extends Mage_Core_M
      */
     public function toOptionArray()
     {
+        $labels = array();
         $options = array(
             array(
                 'label' => 'Fully Taxable',
@@ -47,7 +48,10 @@ class Taxjar_SalesTax_Model_Resource_Tax_Category_Collection extends Mage_Core_M
             );
         }
 
-        $labels = array_column($options, 'label');
+        foreach($options as $option) {
+            $labels[] = $option['label'];
+        }
+
         array_multisort($labels, SORT_ASC, $options);
 
         return $options;

--- a/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category/Collection.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category/Collection.php
@@ -47,6 +47,9 @@ class Taxjar_SalesTax_Model_Resource_Tax_Category_Collection extends Mage_Core_M
             );
         }
 
+        $labels = array_column($options, 'label');
+        array_multisort($labels, SORT_ASC, $options);
+
         return $options;
     }
 }

--- a/app/code/community/Taxjar/SalesTax/Model/Tax/Category.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Tax/Category.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+class Taxjar_SalesTax_Model_Tax_Category extends Mage_Core_Model_Abstract
+{
+    /**
+     * Resource initialization
+     */
+    public function _construct()
+    {
+        $this->_init('taxjar/tax_category');
+    }
+}

--- a/app/code/community/Taxjar/SalesTax/controllers/Adminhtml/TaxjarController.php
+++ b/app/code/community/Taxjar/SalesTax/controllers/Adminhtml/TaxjarController.php
@@ -91,7 +91,7 @@ class Taxjar_SalesTax_Adminhtml_TaxjarController extends Mage_Adminhtml_Controll
     }
 
     /**
-     * Purge nexus addresses on disconnect
+     * Purge product tax categories on disconnect
      */
     private function _purgeProductTaxCategories()
     {

--- a/app/code/community/Taxjar/SalesTax/controllers/Adminhtml/TaxjarController.php
+++ b/app/code/community/Taxjar/SalesTax/controllers/Adminhtml/TaxjarController.php
@@ -57,6 +57,7 @@ class Taxjar_SalesTax_Adminhtml_TaxjarController extends Mage_Adminhtml_Controll
         Mage::getConfig()->reinit();
 
         $this->_purgeNexusAddresses();
+        $this->_purgeProductTaxCategories();
 
         Mage::getSingleton('core/session')->addSuccess(Mage::helper('taxjar')->__('Your TaxJar account has been disconnected.'));
         Mage::dispatchEvent('taxjar_salestax_import_rates');
@@ -86,6 +87,18 @@ class Taxjar_SalesTax_Adminhtml_TaxjarController extends Mage_Adminhtml_Controll
         $nexusAddresses = Mage::getModel('taxjar/tax_nexus')->getCollection();
         foreach($nexusAddresses as $nexusAddress) {
             $nexusAddress->delete();
+        }
+    }
+
+    /**
+     * Purge nexus addresses on disconnect
+     */
+    private function _purgeProductTaxCategories()
+    {
+        $productTaxCategories = Mage::getModel('taxjar/tax_category')->getCollection();
+
+        foreach($productTaxCategories as $productTaxCategory) {
+            $productTaxCategory->delete();
         }
     }
 

--- a/app/code/community/Taxjar/SalesTax/data/salestax_setup/data-upgrade-3.0.0-3.0.1.php
+++ b/app/code/community/Taxjar/SalesTax/data/salestax_setup/data-upgrade-3.0.0-3.0.1.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+try {
+    // Remove old category data
+    Mage::getConfig()->saveConfig('tax/taxjar/categories', '');
+
+    // Update product tax category data
+    Mage::dispatchEvent('taxjar_salestax_import_categories');
+
+} catch (Exception $e) {
+    Mage::logException($e);
+}

--- a/app/code/community/Taxjar/SalesTax/etc/config.xml
+++ b/app/code/community/Taxjar/SalesTax/etc/config.xml
@@ -19,7 +19,7 @@
 <config>
     <modules>
         <Taxjar_SalesTax>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </Taxjar_SalesTax>
     </modules>
     <global>
@@ -50,6 +50,9 @@
                     <tax_nexus>
                         <table>tax_nexus</table>
                     </tax_nexus>
+                    <tax_category>
+                        <table>tj_product_tax_categories</table>
+                    </tax_category>
                 </entities>
             </taxjar_resource>
             <sales>

--- a/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-3.0.0-3.0.1.php
+++ b/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-3.0.0-3.0.1.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+$connection = $installer->getConnection();
+
+try {
+    $table = $installer->getConnection()
+        ->newTable($installer->getTable('taxjar/tax_category'))
+        ->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, null, array(
+            'identity' => true,
+            'unsigned' => true,
+            'nullable' => false,
+            'primary' => true
+        ), 'ID')
+        ->addColumn('product_tax_code', Varien_Db_Ddl_Table::TYPE_TEXT, 32, array(
+            'unsigned' => true,
+        ), 'Product Tax Code')
+        ->addColumn('name', Varien_Db_Ddl_Table::TYPE_TEXT, 255, array(), 'Name')
+        ->addColumn('description', Varien_Db_Ddl_Table::TYPE_TEXT, 255, array(), 'Description')
+        ->addColumn('plus_only', Varien_Db_Ddl_Table::TYPE_BOOLEAN, null, array(), 'Plus Only')
+        ->addIndex($installer->getIdxName('taxjar/tax_category', array('product_tax_code')), 'product_tax_code')
+        ->setComment('TaxJar Product Tax Codes');
+
+    $installer->getConnection()->createTable($table);
+
+} catch (Exception $e) {
+    Mage::logException($e);
+}
+
+$installer->endSetup();


### PR DESCRIPTION
Storing product tax categories as a configuration value won't scale well
as we continue to increase the total number of categories. Reworking
categories to be stored in their own table eliminates this problem and
will support significantly more categories.