### PR TITLE
Improve support for M2E Pro

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Transaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction.php
@@ -234,7 +234,7 @@ class Taxjar_SalesTax_Model_Transaction
 
     /**
      * Get the default provider parameter
-     * 
+     *
      * @param Mage_Sales_Model_Order $order
      * @return mixed|string
      */
@@ -275,7 +275,7 @@ class Taxjar_SalesTax_Model_Transaction
                 /** @var Ess_M2ePro_Model_Order $m2eOrder */
                 $m2eOrder = Mage::getModel('M2ePro/Order')->load($order->getId(), 'magento_order_id');
 
-                if (in_array($m2eOrder->getComponentMode(), ['amazon', 'ebay', 'walmart'])) {
+                if (in_array($m2eOrder->getComponentMode(), array('amazon', 'ebay', 'walmart'))) {
                     $provider = $m2eOrder->getComponentMode();
                 }
             } catch (Ess_M2ePro_Model_Exception $e) {

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction.php
@@ -237,7 +237,7 @@ class Taxjar_SalesTax_Model_Transaction
      *
      * @return string
      */
-    protected function getProvider() {
+    protected function getProvider($order) {
         $provider = Mage::getStoreConfig('tax/taxjar/provider');
 
         if (is_null($provider)) {
@@ -267,6 +267,19 @@ class Taxjar_SalesTax_Model_Transaction
 
             Mage::getConfig()->saveConfig('tax/taxjar/provider', $provider);
             Mage::app()->cleanCache();
+        }
+
+        if (class_exists('Ess_M2ePro_Model_Order')) {
+            try {
+                /** @var Ess_M2ePro_Model_Order $m2eOrder */
+                $m2eOrder = Mage::getModel('M2ePro/Order')->load($order->getId(), 'magento_order_id');
+
+                if (in_array($m2eOrder->getComponentMode(), ['amazon', 'ebay', 'walmart'])) {
+                    $provider = $m2eOrder->getComponentMode();
+                }
+            } catch (Ess_M2ePro_Model_Exception $e) {
+                // noop: M2e order does not exist or component mode can't be loaded
+            }
         }
 
         return $provider;

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction.php
@@ -234,8 +234,9 @@ class Taxjar_SalesTax_Model_Transaction
 
     /**
      * Get the default provider parameter
-     *
-     * @return string
+     * 
+     * @param Mage_Sales_Model_Order $order
+     * @return mixed|string
      */
     protected function getProvider($order) {
         $provider = Mage::getStoreConfig('tax/taxjar/provider');

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Order.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Order.php
@@ -47,7 +47,7 @@ class Taxjar_SalesTax_Model_Transaction_Order extends Taxjar_SalesTax_Model_Tran
             'amount' => $subtotal + $shipping - abs($discount),
             'shipping' => $shipping - abs($shippingDiscount),
             'sales_tax' => $salesTax,
-            'provider' => $this->getProvider()
+            'provider' => $this->getProvider($order)
         );
 
         $this->request = array_merge(

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
@@ -48,7 +48,7 @@ class Taxjar_SalesTax_Model_Transaction_Refund extends Taxjar_SalesTax_Model_Tra
             'amount' => $subtotal + $shipping - abs($discount) + $adjustment,
             'shipping' => $shipping,
             'sales_tax' => $salesTax,
-            'provider' => $this->getProvider()
+            'provider' => $this->getProvider($order)
         );
 
         foreach ($creditmemo->getAllItems() as $item) {


### PR DESCRIPTION
When syncing orders/refunds to TaxJar, first check to see if the M2ePro order class
exists.  If so, try to load the original provider from the order.