### PR TITLE
Update the gift card product tax code

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -260,7 +260,7 @@ class Taxjar_SalesTax_Model_Smartcalcs
                         if ($giftTaxClassCode) {
                             $taxCode = $giftTaxClassCode;
                         } else {
-                            $taxCode = '99999';
+                            $taxCode = '14111803A0001';
                         }
                     }
                 }


### PR DESCRIPTION
Update the gift card tax code from '99999' to '14111803A0001'


### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Updates the default gift card tax code from '99999' to '14111803A0001' for improved accuracy.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
Gift cards used as part of Magento Commerce previously used '99999' to mark them exempt. Using '14111803A0001' is more accurate.

![Screen Shot 2020-02-10 at 5 12 51 PM](https://user-images.githubusercontent.com/44789510/74578832-31d34d00-4f54-11ea-9b05-3192682ea006.png)

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This change has no affect on performance, as we're only changing the tax code that is sent to the API.

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Add a gift card to Magento's shopping cart (note: gift cards are only available in Commerce and B2B editions of Magento)
2. Visit the shopping cart page and enter a city and zip code to estimate taxes.
3. Confirm that no taxes were calculated for the gift card.
