### PR TITLE
Remove plus_only field from PTCs

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Observer/ImportCategories.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/ImportCategories.php
@@ -55,12 +55,10 @@ class Taxjar_SalesTax_Model_Observer_ImportCategories
         foreach ($categoryJson as $json) {
             $category = Mage::getModel('taxjar/tax_category')->load(trim($json['product_tax_code']),
                 'product_tax_code');
-            $plusOnly = (strpos(trim($json['description']), '*(PLUS ONLY)*') !== false) ? true : false;
 
             $category->setProductTaxCode(trim($json['product_tax_code']));
             $category->setName(trim($json['name']));
             $category->setDescription(trim($json['description']));
-            $category->setPlusOnly($plusOnly);
 
             $category->save();
         }

--- a/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category/Collection.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Resource/Tax/Category/Collection.php
@@ -42,8 +42,7 @@ class Taxjar_SalesTax_Model_Resource_Tax_Category_Collection extends Mage_Core_M
 
         foreach ($this as $category) {
             $options[] = array(
-                'label' => $category->getName() . ' (' . $category->getProductTaxCode() . ')' .
-                    ($category->getPlusOnly() ? ' *(PLUS ONLY)*' : ''),
+                'label' => $category->getName() . ' (' . $category->getProductTaxCode() . ')',
                 'value' => $category->getProductTaxCode()
             );
         }

--- a/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-3.0.1-3.0.2.php
+++ b/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-3.0.1-3.0.2.php
@@ -18,7 +18,6 @@
 /** @var Mage_Core_Model_Resource_Setup $installer */
 $installer = $this;
 $installer->startSetup();
-$connection = $installer->getConnection();
 
 try {
     $table = $installer->getConnection()

--- a/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-3.0.1-3.0.2.php
+++ b/app/code/community/Taxjar/SalesTax/sql/salestax_setup/upgrade-3.0.1-3.0.2.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Taxjar_SalesTax
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @category   Taxjar
+ * @package    Taxjar_SalesTax
+ * @copyright  Copyright (c) 2019 TaxJar. TaxJar is a trademark of TPS Unlimited, Inc. (http://www.taxjar.com)
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+/** @var Mage_Core_Model_Resource_Setup $installer */
+$installer = $this;
+$installer->startSetup();
+$connection = $installer->getConnection();
+
+try {
+    $table = $installer->getConnection()
+        ->dropColumn($installer->getTable('taxjar/tax_category'), 'plus_only');
+} catch (Exception $e) {
+    Mage::logException($e);
+}
+
+$installer->endSetup();


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
This PR removes the plus_only flag from the product tax categories.  


### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
The plus_only feature is no longer used and is being removed.  


### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This change has a negligible impact on performance.  

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->

1. Clear the configuration cache from the admin to ensure the extension's setup version is upgraded to 3.0.2.  

2. Ensure the 'plus_only_ column is removed from the table 'tj_product_tax_categories'.
![Screen Shot 2020-04-20 at 4 50 43 PM](https://user-images.githubusercontent.com/44789510/79807173-60402080-8327-11ea-946c-6da62e010830.png)

3. Ensure the "PLUS ONLY" label is removed from the Product Tax Class list of categories (click the select element "TaxJar Category" to expand it). 
![Screen Shot 2020-04-20 at 4 51 40 PM](https://user-images.githubusercontent.com/44789510/79807177-633b1100-8327-11ea-8556-bffd49d48574.png)
