### PR TITLE
Improve error handling during transaction sync

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Client.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Client.php
@@ -26,6 +26,7 @@ class Taxjar_SalesTax_Model_Client
     protected $_apiKey;
     protected $_storeZip;
     protected $_storeRegionCode;
+    protected $_showResponseErrors;
 
     public function __construct()
     {
@@ -100,6 +101,16 @@ class Taxjar_SalesTax_Model_Client
     }
 
     /**
+     * Toggle hiding api response errors
+     * @param bool $toggle
+     * @return void
+     */
+    public function showResponseErrors($toggle)
+    {
+        $this->_showResponseErrors = $toggle;
+    }
+
+    /**
      * Get HTTP Client
      *
      * @param string $url
@@ -137,7 +148,7 @@ class Taxjar_SalesTax_Model_Client
                 $json = $response->getBody();
                 return json_decode($json, true);
             } else {
-                $this->_handleError($errors, $response->getStatus());
+                $this->_handleError($errors, $response);
             }
         } catch (Zend_Http_Client_Exception $e) {
             Mage::throwException(Mage::helper('taxjar')->__('Could not connect to TaxJar.'));
@@ -185,17 +196,21 @@ class Taxjar_SalesTax_Model_Client
      * Handle API errors and throw exception
      *
      * @param array $customErrors
-     * @param string $statusCode
+     * @param Zend_Http_Response $response
      * @return string
      */
-    private function _handleError($customErrors, $statusCode)
+    private function _handleError($customErrors, $response)
     {
         $errors = $this->_defaultErrors() + $customErrors;
+        $statusCode = (int) $response->getStatus();
 
-        if (isset($errors[$statusCode])) {
-            Mage::throwException($errors[$statusCode]);
+        if ($this->_showResponseErrors) {
+            $msg = json_decode($response->getBody(), true);
+            throw new Mage_Api2_Exception($msg['detail'], $statusCode);
+        } elseif (isset($errors[$statusCode])) {
+            throw new Mage_Api2_Exception($errors[$statusCode], $statusCode);
         } else {
-            Mage::throwException($errors['default']);
+            throw new Mage_Api2_Exception($errors['default'], $statusCode);
         }
     }
 

--- a/app/code/community/Taxjar/SalesTax/Model/Client.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Client.php
@@ -203,9 +203,9 @@ class Taxjar_SalesTax_Model_Client
     {
         $errors = $this->_defaultErrors() + $customErrors;
         $statusCode = (int) $response->getStatus();
+        $msg = json_decode($response->getBody(), true);
 
-        if ($this->_showResponseErrors) {
-            $msg = json_decode($response->getBody(), true);
+        if ($this->_showResponseErrors && is_array($msg) && isset($msg['detail'])) {
             throw new Mage_Api2_Exception($msg['detail'], $statusCode);
         } elseif (isset($errors[$statusCode])) {
             throw new Mage_Api2_Exception($errors[$statusCode], $statusCode);

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction.php
@@ -27,6 +27,7 @@ class Taxjar_SalesTax_Model_Transaction
     public function __construct()
     {
         $this->client = Mage::getSingleton('taxjar/client');
+        $this->client->showResponseErrors(true);
         $this->logger = Mage::getSingleton('taxjar/logger')->setFilename('transactions.log');
     }
 

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Order.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Order.php
@@ -101,7 +101,7 @@ class Taxjar_SalesTax_Model_Transaction_Order extends Taxjar_SalesTax_Model_Tran
         } catch (Exception $e) {
             $this->logger->log('Error: ' . $e->getMessage(), 'error');
 
-            $errorStatusCode = array_search($e->getMessage(), $this->transactionErrors());
+            $errorStatusCode = $e->getCode();
 
             // Retry push for not found records using POST
             if (!$forceMethod && $method == 'PUT' && $errorStatusCode == 404) {

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Order.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Order.php
@@ -99,9 +99,8 @@ class Taxjar_SalesTax_Model_Transaction_Order extends Taxjar_SalesTax_Model_Tran
 
             $this->originalOrder->setTjSalestaxSyncDate(gmdate('Y-m-d H:i:s'))->save();
         } catch (Exception $e) {
-            $this->logger->log('Error: ' . $e->getMessage(), 'error');
-
             $errorStatusCode = $e->getCode();
+            $this->logger->log($errorStatusCode . ' Error: ' . $e->getMessage(), 'error');
 
             // Retry push for not found records using POST
             if (!$forceMethod && $method == 'PUT' && $errorStatusCode == 404) {

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
@@ -122,7 +122,7 @@ class Taxjar_SalesTax_Model_Transaction_Refund extends Taxjar_SalesTax_Model_Tra
         } catch (Exception $e) {
             $this->logger->log('Error: ' . $e->getMessage(), 'error');
 
-            $errorStatusCode = array_search($e->getMessage(), $this->transactionErrors());
+            $errorStatusCode = $e->getCode();
 
             // Retry push for not found records using POST
             if (!$forceMethod && $method == 'PUT' && $errorStatusCode == 404) {

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Refund.php
@@ -120,9 +120,8 @@ class Taxjar_SalesTax_Model_Transaction_Refund extends Taxjar_SalesTax_Model_Tra
 
             $this->originalRefund->setTjSalestaxSyncDate(gmdate('Y-m-d H:i:s'))->save();
         } catch (Exception $e) {
-            $this->logger->log('Error: ' . $e->getMessage(), 'error');
-
             $errorStatusCode = $e->getCode();
+            $this->logger->log($errorStatusCode . ' Error: ' . $e->getMessage(), 'error');
 
             // Retry push for not found records using POST
             if (!$forceMethod && $method == 'PUT' && $errorStatusCode == 404) {


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
Currently error messages returned by the API are ignored in favor of predefined error messages.  This change logs API error messages during transaction sync and adds the option to fall back to default messaging when desired.

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
This PR allows logging API specific errors during transaction sync.  
![Screen Shot 2020-04-29 at 1 35 53 PM](https://user-images.githubusercontent.com/44789510/80639169-da0a9500-8a1e-11ea-914e-3449d405e218.png)


### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This PR should have no change to performance.  

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1.  Create, invoice and ship an order so that it syncs to TaxJar
2. Force an error to occur.  For example, **temporarily** modify the subtotal to an invalid amount in Taxjar_SalesTax_Model_Transaction_Order:
`$subtotal = (float) $order->getSubtotal() * 2;`

3.  Attempt to backfill the transactions and confirm that the specific error message is reported.  

