### PR TITLE
Use the first street in multi-street addresses

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Smartcalcs.php
@@ -33,7 +33,7 @@ class Taxjar_SalesTax_Model_Smartcalcs
     /**
      * Tax calculation for order
      *
-     * @param  object $address
+     * @param  Mage_Sales_Model_Quote_Address $address
      * @return void
      */
     public function initTaxForOrder($address)
@@ -74,7 +74,7 @@ class Taxjar_SalesTax_Model_Smartcalcs
             'to_zip' => $address->getPostcode(),
             'to_state' => $address->getRegionCode(),
             'to_city' => $address->getCity(),
-            'to_street' => $address->getData('street'),
+            'to_street' => $address->getStreet(1)
         );
 
         $shipping = (float) $address->getShippingAmount();

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction.php
@@ -57,7 +57,7 @@ class Taxjar_SalesTax_Model_Transaction
         $fromPostcode = Mage::getStoreConfig('shipping/origin/postcode', $storeId);
         $fromState = Mage::getModel('directory/region')->load(Mage::getStoreConfig('shipping/origin/region_id', $storeId))->getCode();
         $fromCity = Mage::getStoreConfig('shipping/origin/city', $storeId);
-        $fromStreet = Mage::getStoreConfig('shipping/origin/street_line1', $storeId) . Mage::getStoreConfig('shipping/origin/street_line2', $storeId);
+        $fromStreet = Mage::getStoreConfig('shipping/origin/street_line1', $storeId);
 
         return array(
             'from_country' => $fromCountry,
@@ -86,7 +86,7 @@ class Taxjar_SalesTax_Model_Transaction
             'to_zip' => $address->getPostcode(),
             'to_state' => $address->getRegionCode(),
             'to_city' => $address->getCity(),
-            'to_street' => $address->getData('street')
+            'to_street' => $address->getStreet(1)
         );
 
         return $toAddress;


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
This PR standardizes all address usage to only use the first line of the street.  

![Screen Shot 2020-07-08 at 11 48 12 AM](https://user-images.githubusercontent.com/44789510/86952923-ef7ff780-c110-11ea-90fc-ab9d4fe57755.png)

In the above image, "Third Floor" should be omitted when determining the address.  

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->
This PR has no impact on performance.  

### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Setup a shipping origin address with multi-streets
2. Create an order with a multi-street shipping address
3. Confirm that only the first line of each street is used when calculating taxes and syncing transactions to TaxJar