### PR TITLE
Change the "transaction sync" setting to use scope

### DIFF
--- a/app/code/community/Taxjar/SalesTax/Model/Observer/AdminMenuItems.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/AdminMenuItems.php
@@ -19,8 +19,9 @@ class Taxjar_SalesTax_Model_Observer_AdminMenuItems
 {
     public function execute(Varien_Event_Observer $observer)
     {
-        $connected = Mage::getStoreConfig('tax/taxjar/connected');
-        $transactionSync = Mage::getStoreConfig('tax/taxjar/transactions');
+        $storeId = Mage::app()->getStore(Mage::app()->getRequest()->getParam('store'))->getId();
+        $connected = Mage::getStoreConfig('tax/taxjar/connected', $storeId);
+        $transactionSync = Mage::getStoreConfig('tax/taxjar/transactions', $storeId);
 
         if (!$connected) {
             $config = Mage::getSingleton('admin/config')->getAdminhtmlConfig()->getNode();

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/SyncRefund.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/SyncRefund.php
@@ -23,23 +23,15 @@ class Taxjar_SalesTax_Model_Observer_SyncRefund
      */
     public function execute(Varien_Event_Observer $observer)
     {
-        $syncEnabled = Mage::getStoreConfig('tax/taxjar/transactions');
-
-        if (!$syncEnabled) {
-            return $this;
-        }
-
         if (!Mage::registry('taxjar_sync_refund')) {
             Mage::register('taxjar_sync_refund', true);
         } else {
             return $this;
-
         }
 
         /** @var Mage_Sales_Model_Order_Creditmemo $creditmemo */
         $creditmemo = $observer->getCreditmemo();
         $order = $creditmemo->getOrder();
-
         $orderTransaction = Mage::getModel('taxjar/transaction_order');
 
         if ($orderTransaction->isSyncable($order)) {

--- a/app/code/community/Taxjar/SalesTax/Model/Observer/SyncTransaction.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Observer/SyncTransaction.php
@@ -21,13 +21,8 @@ class Taxjar_SalesTax_Model_Observer_SyncTransaction
      * @param Varien_Event_Observer $observer
      * @return $this
      */
-    public function execute(Varien_Event_Observer $observer) {
-        $syncEnabled = Mage::getStoreConfig('tax/taxjar/transactions');
-
-        if (!$syncEnabled) {
-            return $this;
-        }
-
+    public function execute(Varien_Event_Observer $observer)
+    {
         if (!Mage::registry('taxjar_sync')) {
             Mage::register('taxjar_sync', true);
         } else {

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Comment.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Comment.php
@@ -29,7 +29,8 @@ class Taxjar_SalesTax_Model_Transaction_Comment
      */
     public function getCommentText()
     {
-        $isEnabled = Mage::getStoreConfig('tax/taxjar/transactions');
+        $storeId = Mage::app()->getStore(Mage::app()->getRequest()->getParam('store'))->getId();
+        $isEnabled = Mage::getStoreConfig('tax/taxjar/transactions', $storeId);
         $htmlString = "<p class='note'><span>Sync orders and refunds with TaxJar for automated sales tax reporting and filing. Complete and closed transactions sync automatically on update.</span></p><br/>";
 
         if ($isEnabled) {

--- a/app/code/community/Taxjar/SalesTax/Model/Transaction/Order.php
+++ b/app/code/community/Taxjar/SalesTax/Model/Transaction/Order.php
@@ -124,6 +124,11 @@ class Taxjar_SalesTax_Model_Transaction_Order extends Taxjar_SalesTax_Model_Tran
      */
     public function isSyncable($order) {
         $states = array('complete', 'closed');
+        $syncEnabled = Mage::getStoreConfig('tax/taxjar/transactions', $order->getStore()->getId());
+
+        if (!$syncEnabled) {
+            return false;
+        }
 
         if (!in_array($order->getState(), $states)) {
             return false;


### PR DESCRIPTION
### Context
<!-- Why is this change necessary? Write one or two sentences to explain what's going on. -->
The transaction sync setting only checks the default store scope.  This change supports loading the current store scope value.  

### Description
<!-- What does this PR change? If it's a bug, describe the fix. If it's a feature, post screenshots or a video. -->
When checking to see if transaction sync is enabled, pass the current store id to load the value for that store.

### Performance
<!-- How does this PR impact the area that's being changed? Prove it out. This can be an informal benchmark, EXPLAIN ANALYZE output, etc. -->


### Testing
<!-- How do we test this PR? **This section is critical.** Some ideas:
- Provide clear steps to reproduce w/ test data
- Show us how you tested the PR
- Call out specific areas of concern
-->
1. Configure Magento to use multiple stores
2. Enable transaction sync for the default store, but disable it for a specific store
3. Place an order on that store, invoice and ship it.  Confirm that the order does not sync to TaxJar

